### PR TITLE
Proper mutexing 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 compile.sh
 binaries/PanelExplorer.exe
 binaries/PanelExplorer
+.vscode

--- a/demo.go
+++ b/demo.go
@@ -412,13 +412,11 @@ func stepDemo(step uint32) {
 	binary.LittleEndian.PutUint32(header, uint32(len(pbdata))) // Fill it in
 	pbdata = append(header, pbdata...)
 
-	wsslice.Iter(func(w *wsclient) {
-		w.msgToClient <- &wsToClient{
-			RWPASCIIToPanel:    strings.Join(helpers.InboundMessagesToRawPanelASCIIstrings(incomingMessages), "\n"),
-			RWPJSONToPanel:     string(stateAsJsonString),
-			RWPProtobufToPanel: prettyHexPrint(pbdata),
-			StepDescription:    StepDescription,
-		}
+	BroadcastMessage(&wsToClient{
+		RWPASCIIToPanel:    strings.Join(helpers.InboundMessagesToRawPanelASCIIstrings(incomingMessages), "\n"),
+		RWPJSONToPanel:     string(stateAsJsonString),
+		RWPProtobufToPanel: prettyHexPrint(pbdata),
+		StepDescription:    StepDescription,
 	})
 
 	incoming <- incomingMessages

--- a/eventplot.go
+++ b/eventplot.go
@@ -141,10 +141,9 @@ func eventPlot(Event *rwp.HWCEvent) {
 
 	}
 
-	eventMessage := &wsToClient{
+	BroadcastMessage(&wsToClient{
 		ControlBlock: svg,
-	}
-	wsslice.Iter(func(w *wsclient) { w.msgToClient <- eventMessage })
+	})
 }
 
 func getTypeCode(hwc uint32) string {

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,6 @@ require (
 	github.com/antchfx/xpath v0.0.0-20170515025933-1f3266e77307 // indirect
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/disintegration/gift v1.2.1 // indirect
-	github.com/jinzhu/copier v0.3.5 // indirect
 	github.com/mattn/go-colorable v0.1.9 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/miekg/dns v1.1.27 // indirect

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,6 @@ github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWm
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grandcat/zeroconf v1.0.0 h1:uHhahLBKqwWBV6WZUDAT71044vwOTL+McW0mBJvo6kE=
 github.com/grandcat/zeroconf v1.0.0/go.mod h1:lTKmG1zh86XyCoUeIHSA4FJMBwCJiQmGfcP2PdzytEs=
-github.com/jinzhu/copier v0.3.5 h1:GlvfUwHk62RokgqVNvYsku0TATCF7bAHVwEXoBh3iJg=
-github.com/jinzhu/copier v0.3.5/go.mod h1:DfbEm0FYsaqBcKcFuvmOZb218JkPGtvSHsKg8S8hyyg=
 github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.9 h1:sqDoxXbdeALODt0DAeJCVp38ps9ZogZEAXjus69YV3U=
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=


### PR DESCRIPTION
Hi Kasper, 

First of all, I know I mentioned it often but PLEASE try to use earlie return, it is a standard pattern and makes code much faster to reason about, also it shows where functions end without scrolling to the end of them. Keep in mind that code is never only read by oneself, and even oneself benefits massively from having easy to read code in a couple of weeks time
Secondly: Your .Iter function gets you in major trouble, as it passes a complex object and then marshals it for as many times as there are clients on individual go routines. That is not only inefficient, but also causes more potential datarace headaches than needed. I have changed it to a global broadcast function that does the marshaling once and then passes the bytes to the individual ws connections. Bytes are straight forward and safe to copy, and the expensive marshal function is only called once, in a syncronous fashion, meaning it is protected by the mutex that should still be RLocked in the function that calls Broadcast. Also it is easier to read than the function passing + channel operation construct

Finally we can remove the very expensive Copier calls and library. Copier uses reflections inside and should really only ever be used as a very last resort. (or even never, as it could potentially make things worse like it did here)
Also then the Mutex on the individual entries can be removed, as in every situation one would need to lock the parent mutex on .entries anyways. Removing this spares you from several dozends of locks and unlocks that are redundant.

As a final point: using RWMutexes instead of the normal ones can give some advantages (there can be multiple RLocks at the same time but only ever one Lock used for writing)

Hope this helps, let me know if you have more questions